### PR TITLE
fix(readme): installation npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ Integrates Minio with Nest
 ## Installation
 
 ```bash
-npm install @svtslv/minio minio
+npm install @svtslv/nestjs-minio minio
+```
+or
+```
+yarn add @svtslv/nestjs-minio minio
 ```
 
 ```bash
 npm install -D @types/minio
+```
+or
+```
+yarn add -D @types/minio
 ```
 
 You can also use the interactive CLI

--- a/README.md
+++ b/README.md
@@ -18,17 +18,9 @@ Integrates Minio with Nest
 ```bash
 npm install @svtslv/nestjs-minio minio
 ```
-or
-```
-yarn add @svtslv/nestjs-minio minio
-```
 
 ```bash
 npm install -D @types/minio
-```
-or
-```
-yarn add -D @types/minio
 ```
 
 You can also use the interactive CLI


### PR DESCRIPTION
The npm install was pointing to a non existing package. Updated to use the correct one. (@svtslv/nestjs-minio instead of @svtslv/minio minio)

Also added the option to install with yarn